### PR TITLE
Bagnon Plugin: Using bag/slot as default for GetTooltipText

### DIFF
--- a/Plugins/bagnon.lua
+++ b/Plugins/bagnon.lua
@@ -18,10 +18,14 @@ if IsAddOnLoaded("Bagnon") then
         -- load everything immediately, so the OnUpdate needs to run until those frames are opened.
         if (bag == 0 and slot == 0) or (bag == 100 and slot == 0) then return end
 
-        -- For cached Bagnon bags, GetContainerItemLink(bag, slot) would not work in CanIMogIt:GetTooltipText(nil, bag, slot).
-        -- Therefore provide GetTooltipText() with itemLink here.
-        local itemLink = self:GetParent():GetItem()
-        CIMI_SetIcon(self, BagnonItemButton_CIMIUpdateIcon, CanIMogIt:GetTooltipText(itemLink))
+        -- For cached Bagnon bags, GetContainerItemLink(bag, slot) would not work in GetTooltipText(nil, bag, slot).
+        -- Therefore use GetTooltipText(self:GetParent():GetItem()) as fallback.
+        if (CanIMogIt:GetTooltipText(nil, bag, slot) == "") then
+            CIMI_SetIcon(self, BagnonItemButton_CIMIUpdateIcon, CanIMogIt:GetTooltipText(self:GetParent():GetItem()))
+        else
+            CIMI_SetIcon(self, BagnonItemButton_CIMIUpdateIcon, CanIMogIt:GetTooltipText(nil, bag, slot))
+        end
+
     end
 
     function CIMI_BagnonUpdate(self)


### PR DESCRIPTION
Somebody recently told me that getting the item info from bag/slot is generally better than using the item link. Because the bag/slot may contain a customised version of an item whereas the item link only holds information about the item's generic version. I don't know if this is the case and if it would affect CIMI. But never the less I changed the code such that bag/slot is now the default for GetTooltipText and only if this fails, the item link is used.