### PR TITLE
Make the frame wider

### DIFF
--- a/options.lua
+++ b/options.lua
@@ -223,12 +223,13 @@ local changesSavedStack = {}
 local function changesSavedText()
     local frame = CreateFrame("Frame", "CanIMogIt_ChangesSaved", CanIMogIt.frame)
     local text = frame:CreateFontString(nil, "ARTWORK", "GameFontHighlight")
+    text:SetJustifyH("RIGHT")
     text:SetText(CanIMogIt.YELLOW .. L["Changes saved!"])
 
     text:SetAllPoints()
 
     frame:SetPoint("BOTTOMRIGHT", -20, 10)
-    frame:SetSize(100, 20)
+    frame:SetSize(200, 20)
     frame:SetShown(false)
     CanIMogIt.frame.changesSavedText = frame
 end


### PR DESCRIPTION
Before ("Changes saved!" translation is cropped)

![Wow_4BWRx2Y3qy](https://user-images.githubusercontent.com/5046855/97226432-07c17280-17e5-11eb-9338-be93bb827bdc.jpg)


After (frame is 2x wider, text aligned to right, so English text will not be shifted to the left)

![Wow_aQ9iu7bOWw](https://user-images.githubusercontent.com/5046855/97226553-317a9980-17e5-11eb-9a20-6d61e56fe4c5.jpg)