### PR TITLE
Fix error when generating tooltip for crafting reagents

### DIFF
--- a/tooltips.lua
+++ b/tooltips.lua
@@ -334,7 +334,7 @@ hooksecurefunc(GameTooltip, "SetGuildBankItem",
 -- TODO DF: Make sure this hook in still needed. The crafting system got reworked.
 hooksecurefunc(GameTooltip, "SetRecipeReagentItem",
     function(tooltip, itemID, index)
-        addToTooltip(tooltip, C_TradeSkillUI.GetRecipeReagentItemLink(itemID, index))
+        addToTooltip(tooltip, C_TradeSkillUI.GetRecipeFixedReagentItemLink(itemID, index))
         VVDebugPrint(tooltip, "SetRecipeReagentItem")
     end
 )


### PR DESCRIPTION
Replacing removed https://wowpedia.fandom.com/wiki/API_C_TradeSkillUI.GetRecipeReagentItemLink with new https://wowpedia.fandom.com/wiki/API_C_TradeSkillUI.GetRecipeFixedReagentItemLink

Unsure when https://wowpedia.fandom.com/wiki/API_C_TradeSkillUI.GetRecipeQualityReagentItemLink will need to be used instead so this is just to fix the immediately known error