### PR TITLE
Add BigWigs Packager support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '**'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      CF_API_KEY: ${{ secrets.CF_API_KEY }}
+      WOWI_API_TOKEN: ${{ secrets.WOWI_API_TOKEN }}
+      GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }} 
+      WAGO_API_TOKEN: ${{ secrets.WAGO_API_TOKEN }} 
+    steps:
+      - name: Clone project
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Package and release
+        uses: BigWigsMods/packager@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Libs/
 *.code-workspace
+.release

--- a/CanIMogIt.toc
+++ b/CanIMogIt.toc
@@ -14,7 +14,10 @@
 ## Notes-zhCN: @localization(locale="zhCN", key="Adds tooltips to items showing if you have learned a transmog appearance.")@
 ## Notes-zhTW: @localization(locale="zhTW", key="Adds tooltips to items showing if you have learned a transmog appearance.")@
 ## X-Category: Transmogrify
-## X-Website: http://mods.curse.com/addons/wow/can-i-mog-it
+## X-Website: https://www.curseforge.com/wow/addons/can-i-mog-it
+## X-Curse-Project-ID: 100617
+## X-WoWI-ID: 24015
+## X-Wago-ID: Qb6mg9GP
 ## SavedVariables: CanIMogItOptions, CanIMogItDatabase
 ## OptionalDeps: AdiBags, ArkInventory, ElvUI, LiteBag, Bagnon, cargBags_Nivaya, Auctionator
 embeds.xml


### PR DESCRIPTION
This code will fully automate releases to CurseForge, WoWInterface, Wago Addons, and GitHub.

Some additional configuration is required:
1. Disable current integration with CurseForge. This code will replace it.
2. In this repository settings (Settings -> Secret -> Actions) three secrets with API keys needs to be declared:
`CF_API_KEY` - https://wow.curseforge.com/account/api-tokens
`WOWI_API_TOKEN` - https://www.wowinterface.com/downloads/filecpl.php?action=apitokens
`WAGO_API_TOKEN` - https://addons.wago.io/account/apikeys

After that every tag pushed to this repository will start the automatic release process.
The changelog is still using `CHANGELOG.md` and all other replacements that were made by CF packager will still work.

Additionally, I would kindly ask you to edit the Wago project and disable the option that blocks third-party updaters.