### PR TITLE
Unlearnable vs Unusable based on usability overlay & config option

### DIFF
--- a/classes/appearanceData.lua
+++ b/classes/appearanceData.lua
@@ -60,12 +60,19 @@ function CanIMogIt.AppearanceData:CalculateKnownStatus()
             status = CanIMogIt.KNOWN_FROM_ANOTHER_ITEM_AND_CHARACTER
         end
     else
-        if self.isValidAppearanceForCharacter then
+        if self.characterCanLearnTransmog then
             -- The player does not know the appearance and the character
             -- can learn this appearance.
-            status = CanIMogIt.UNKNOWN
+            -- Check if option is enabled to mark as unlearnable if unusable
+            if CanIMogItOptions and CanIMogItOptions["markUnlearnableIfUnusable"] and not self.isValidAppearanceForCharacter then
+                -- Option enabled: mark as unlearnable if character can't use it
+                status = CanIMogIt.UNKNOWABLE_BY_CHARACTER
+            else
+                -- Default: mark as unknown (learnable) even if can't equip/use it
+                status = CanIMogIt.UNKNOWN
+            end
         else
-            -- Warbound shouldn't be possible in this state.
+            -- The character cannot learn this appearance.
             status = CanIMogIt.UNKNOWABLE_BY_CHARACTER
         end
     end

--- a/options.lua
+++ b/options.lua
@@ -58,6 +58,7 @@ CanIMogItOptions_Defaults = {
         ["showMountItems"] = true,
         ["showCatalizableItems"] = true,
         ["showEnsembleItems"] = true,
+        ["markUnlearnableIfUnusable"] = false,
     },
 }
 
@@ -122,6 +123,10 @@ CanIMogItOptions_DisplayData = {
     ["showEnsembleItems"] = {
         ["displayName"] = L["Show Ensemble Items"],
         ["description"] = L["Show tooltips and overlays on Ensemble Items (otherwise, shows as not transmoggable)."]
+    },
+    ["markUnlearnableIfUnusable"] = {
+        ["displayName"] = L["Mark unlearnable if unusable"],
+        ["description"] = L["If enabled, items that cannot be equipped/used by your character will be marked as unlearnable, even if they could technically be learned."]
     },
 }
 
@@ -513,7 +518,85 @@ local function newRadioGrid(parent, variableName)
     -- sample:SetText("example.")
     -- sample:SetPoint("TOPLEFT", frame, "BOTTOMLEFT")
 
+    -- Store radio buttons and variable name for refresh
+    frame.allRadios = allRadios
+    frame.variableName = variableName
+
     return frame
+end
+
+
+local function refreshOptionsUI()
+    -- Refresh all checkboxes
+    if CanIMogIt.frame.debug then
+        CanIMogIt.frame.debug:SetChecked(CanIMogIt.frame.debug:GetValue())
+    end
+    if CanIMogIt.frame.showEquippableOnly then
+        CanIMogIt.frame.showEquippableOnly:SetChecked(CanIMogIt.frame.showEquippableOnly:GetValue())
+    end
+    if CanIMogIt.frame.markUnlearnableIfUnusable then
+        CanIMogIt.frame.markUnlearnableIfUnusable:SetChecked(CanIMogIt.frame.markUnlearnableIfUnusable:GetValue())
+    end
+    if CanIMogIt.frame.showTransmoggableOnly then
+        CanIMogIt.frame.showTransmoggableOnly:SetChecked(CanIMogIt.frame.showTransmoggableOnly:GetValue())
+    end
+    if CanIMogIt.frame.showUnknownOnly then
+        CanIMogIt.frame.showUnknownOnly:SetChecked(CanIMogIt.frame.showUnknownOnly:GetValue())
+    end
+    if CanIMogIt.frame.showSetInfo then
+        CanIMogIt.frame.showSetInfo:SetChecked(CanIMogIt.frame.showSetInfo:GetValue())
+    end
+    if CanIMogIt.frame.showItemIconOverlay then
+        CanIMogIt.frame.showItemIconOverlay:SetChecked(CanIMogIt.frame.showItemIconOverlay:GetValue())
+    end
+    if CanIMogIt.frame.showVerboseText then
+        CanIMogIt.frame.showVerboseText:SetChecked(CanIMogIt.frame.showVerboseText:GetValue())
+    end
+    if CanIMogIt.frame.showSourceLocationTooltip then
+        CanIMogIt.frame.showSourceLocationTooltip:SetChecked(CanIMogIt.frame.showSourceLocationTooltip:GetValue())
+    end
+    if CanIMogIt.frame.printDatabaseScan then
+        CanIMogIt.frame.printDatabaseScan:SetChecked(CanIMogIt.frame.printDatabaseScan:GetValue())
+    end
+    if CanIMogIt.frame.showToyItems then
+        CanIMogIt.frame.showToyItems:SetChecked(CanIMogIt.frame.showToyItems:GetValue())
+    end
+    if CanIMogIt.frame.showPetItems then
+        CanIMogIt.frame.showPetItems:SetChecked(CanIMogIt.frame.showPetItems:GetValue())
+    end
+    if CanIMogIt.frame.showMountItems then
+        CanIMogIt.frame.showMountItems:SetChecked(CanIMogIt.frame.showMountItems:GetValue())
+    end
+    if CanIMogIt.frame.showCatalizableItems then
+        CanIMogIt.frame.showCatalizableItems:SetChecked(CanIMogIt.frame.showCatalizableItems:GetValue())
+    end
+    if CanIMogIt.frame.showEnsembleItems then
+        CanIMogIt.frame.showEnsembleItems:SetChecked(CanIMogIt.frame.showEnsembleItems:GetValue())
+    end
+
+    -- Refresh radio buttons
+    if CanIMogIt.frame.iconLocation and CanIMogIt.frame.iconLocation.allRadios and CanIMogIt.frame.iconLocation.variableName then
+        local radioFrame = CanIMogIt.frame.iconLocation
+        local currentValue = CanIMogItOptions[radioFrame.variableName]
+        local locationMap = {
+            ["TopLeft"] = "TOPLEFT",
+            ["Top"] = "TOP",
+            ["TopRight"] = "TOPRIGHT",
+            ["Left"] = "LEFT",
+            ["Center"] = "CENTER",
+            ["Right"] = "RIGHT",
+            ["BottomLeft"] = "BOTTOMLEFT",
+            ["Bottom"] = "BOTTOM",
+            ["BottomRight"] = "BOTTOMRIGHT"
+        }
+        for _, radio in ipairs(radioFrame.allRadios) do
+            local radioName = radio:GetName()
+            local location = string.match(radioName, "_(%w+)$")
+            if location and locationMap[location] then
+                radio:SetChecked(currentValue == locationMap[location])
+            end
+        end
+    end
 end
 
 
@@ -521,6 +604,7 @@ local function createOptionsMenu()
     -- define the checkboxes
     CanIMogIt.frame.debug =  newCheckbox(CanIMogIt.frame, "debug", debugCheckboxOnClick)
     CanIMogIt.frame.showEquippableOnly = newCheckbox(CanIMogIt.frame, "showEquippableOnly")
+    CanIMogIt.frame.markUnlearnableIfUnusable = newCheckbox(CanIMogIt.frame, "markUnlearnableIfUnusable")
     CanIMogIt.frame.showTransmoggableOnly = newCheckbox(CanIMogIt.frame, "showTransmoggableOnly")
     CanIMogIt.frame.showUnknownOnly = newCheckbox(CanIMogIt.frame, "showUnknownOnly")
     CanIMogIt.frame.showSetInfo = newCheckbox(CanIMogIt.frame, "showSetInfo")
@@ -538,7 +622,8 @@ local function createOptionsMenu()
     -- position the checkboxes
     CanIMogIt.frame.debug:SetPoint("TOPLEFT", 16, -16)
     CanIMogIt.frame.showEquippableOnly:SetPoint("TOPLEFT", CanIMogIt.frame.debug, "BOTTOMLEFT")
-    CanIMogIt.frame.showTransmoggableOnly:SetPoint("TOPLEFT", CanIMogIt.frame.showEquippableOnly, "BOTTOMLEFT")
+    CanIMogIt.frame.markUnlearnableIfUnusable:SetPoint("TOPLEFT", CanIMogIt.frame.showEquippableOnly, "BOTTOMLEFT")
+    CanIMogIt.frame.showTransmoggableOnly:SetPoint("TOPLEFT", CanIMogIt.frame.markUnlearnableIfUnusable, "BOTTOMLEFT")
     CanIMogIt.frame.showUnknownOnly:SetPoint("TOPLEFT", CanIMogIt.frame.showTransmoggableOnly, "BOTTOMLEFT")
     CanIMogIt.frame.showSetInfo:SetPoint("TOPLEFT", CanIMogIt.frame.showUnknownOnly, "BOTTOMLEFT")
     CanIMogIt.frame.showItemIconOverlay:SetPoint("TOPLEFT", CanIMogIt.frame.showSetInfo, "BOTTOMLEFT")
@@ -553,6 +638,9 @@ local function createOptionsMenu()
     CanIMogIt.frame.showEnsembleItems:SetPoint("TOPLEFT", CanIMogIt.frame.showCatalizableItems, "BOTTOMLEFT")
 
     changesSavedText()
+    
+    -- Refresh UI when frame is shown
+    CanIMogIt.frame:SetScript("OnShow", refreshOptionsUI)
 end
 
 


### PR DESCRIPTION
As of DragonFlight all transmog items are learnable by selling it to a vendor and do not require being equipped to learn the transmog. 

* Added new option "Mark unlearnable if unusable" to mark items as unlearnable if they cannot be equipped/used by your character, even if they could technically be learned. (X vs star in AH based on transmog usability). This allows clear visual distinction of all unknown vs transmoggable unknowns)... Ie Staves as Death Knight. I may want to learn staff transmog that cannot be used on that class... Someone may not want to.

* Updated appearance data logic to respect the new option when determining item status.

* Added UI refresh **workaround** functionality to the options frame. Note: The checkmarks are broken somehow in a way i cannot figure out. This is a workaround that requires clicking to a different settings frame and back in order for checkmarks to refresh properly. They work 'fine' if the option starts as 'off' and they do NOT work fine if the option starts as 'on' in the settings. This allows me to click elsewhere and back to refresh the state vs doing full UI reload.
--
New Behavior - Option unchecked
<img width="1714" height="547" alt="image" src="https://github.com/user-attachments/assets/fcca9f69-80bd-458c-954d-8a4866d49f6c" />
---
Old behavior - Option checked (they are marked unlearnable)
---
<img width="1736" height="564" alt="image" src="https://github.com/user-attachments/assets/6558d1a4-8926-4bad-a56d-0bb56e061c5d" />

